### PR TITLE
feat: 딥러닝을 위한 더미 데이터 자동 생성 스크립트 추가

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -1,5 +1,6 @@
 # app/core/config.py
 from pydantic_settings import BaseSettings
+import os
 
 class Settings(BaseSettings):
     DATABASE_URL: str
@@ -11,6 +12,14 @@ class Settings(BaseSettings):
     KAKAO_REST_API_KEY: str
 
     class Config:
-        env_file = ".env"
+        env_file = (
+            ".env.local" if os.getenv("ENV") == "local"
+            else ".env.docker" if os.getenv("ENV") == "docker"
+            else ".env"  # fallback
+        )
 
 settings = Settings()
+
+print(">>> Loaded ENV:", os.getenv("ENV"))
+print("✅ Loaded DATABASE_URL:", repr(settings.DATABASE_URL))
+print("✅ Loaded ELASTICSEARCH_HOSTS:", repr(settings.ELASTICSEARCH_HOSTS))

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -19,7 +19,7 @@ services:
     image: elastic/elasticsearch:8.15.2
     container_name: tripmateai-elasticsearch
     env_file:
-      - .env
+      - .env.docker
     environment:
       - discovery.type=single-node
       - xpack.security.enabled=false
@@ -32,6 +32,8 @@ services:
   kibana:
     image: docker.elastic.co/kibana/kibana:8.15.2
     container_name: kibana
+    env_file:
+      - .env.docker
     environment:
       - ELASTICSEARCH_HOSTS=${ELASTICSEARCH_HOSTS}
     ports:

--- a/scripts/populate_dummy_data.py
+++ b/scripts/populate_dummy_data.py
@@ -1,0 +1,77 @@
+from sqlalchemy.orm import Session
+from app.db.session import SessionLocal
+from app.db.models.user import User
+from app.db.models.location import Location
+from app.db.models.bookmark import UserBookmark
+from app.core.config import settings
+from elasticsearch import Elasticsearch
+from elasticsearch.helpers import bulk
+from uuid import uuid4
+import random
+from datetime import datetime, timedelta
+
+db: Session = SessionLocal()
+
+# 1. 장소 불러오기
+locations = db.query(Location).filter(
+    Location.use_yn == "Y",
+    Location.delete_yn == "N"
+).all()
+
+if not locations:
+    raise Exception("장소가 없습니다.")
+
+# 2. 사용자 1000명 생성
+users = []
+for i in range(1000):
+    u = User(
+        id=uuid4(),
+        email=f"user{i}@test.com",
+        password_hash="dummyhash",
+        name=f"User{i}",
+        year_of_birth=random.randint(1970, 2010),
+        country_code="KR",
+        use_yn="Y",
+        delete_yn="N"
+    )
+    db.add(u)
+    users.append(u)
+
+db.commit()
+
+# 3. 북마크 (유저당 5~10개)
+for user in users:
+    bookmarked = random.sample(locations, random.randint(5, 10))
+    for loc in bookmarked:
+        db.add(UserBookmark(user_id=user.id, location_id=loc.id))
+
+db.commit()
+
+# 4. 유저 이벤트 로그 (Elasticsearch)
+es = Elasticsearch([settings.ELASTICSEARCH_HOSTS])
+actions = ["view", "click", "bookmark"]
+logs = []
+
+for user in users:
+    num_logs = random.randint(200, 500)
+    for _ in range(num_logs):
+        loc = random.choice(locations)
+        action = random.choice(actions)
+        days_ago = random.randint(0, 30)
+        seconds_offset = random.randint(0, 86400)
+        timestamp = datetime.now() - timedelta(days=days_ago, seconds=seconds_offset)
+
+        logs.append({
+            "_index": "user-logs",
+            "_source": {
+                "user_id": str(user.id),
+                "location_id": str(loc.id),
+                "action": action,
+                "timestamp": timestamp.isoformat()
+            }
+        })
+
+# Bulk insert into Elasticsearch
+bulk(es, logs)
+
+print("딥러닝을 위한 더미 데이터 대량 생성 완료")


### PR DESCRIPTION
## 개요
딥러닝 모델 학습 및 평가를 위해 다음 데이터를 자동으로 대량 생성하는 스크립트 추가
- PostgreSQL: 사용자, 북마크
- Elasticsearch: 유저 이벤트 로그

## 주요 변경사항
- `populate_dummy_data.py` 스크립트 추가  
  - DB 연결: `SessionLocal()`  
  - 장소 조회: `Location.use_yn == "Y"` & `delete_yn == "N"` 필터링  
  - 사용자 1,000명 생성 (`User` 모델)  
  - 사용자당 랜덤 5~10개 북마크 생성 (`UserBookmark` 모델)  
  - Elasticsearch 연결: `settings.ELASTICSEARCH_HOSTS`  
  - 이벤트 로그(“view”, “click”, “bookmark”)를 200~500개/유저 생성  
  - `bulk` API로 한 번에 `user-logs` 인덱스에 삽입  
  - 최종 완료 메시지 출력  
