### PR TITLE
feat: ElasticSearch 인덱스 구조 개선 및 PostgreSQL 백업 자동화 인프라 구축

### DIFF
--- a/Dockerfile.pgbackup
+++ b/Dockerfile.pgbackup
@@ -1,0 +1,16 @@
+FROM postgres:14
+
+RUN apt update && apt install -y cron
+
+COPY scripts/pg_backup.sh /usr/local/bin/pg_backup.sh
+COPY scripts/pg_cleanup_old.sh /usr/local/bin/pg_cleanup_old.sh
+RUN chmod +x /usr/local/bin/pg_backup.sh /usr/local/bin/pg_cleanup_old.sh
+
+# cron 등록
+RUN echo "0 0 * * * /usr/local/bin/pg_backup.sh >> /logs/pg/backup/backup.log 2>&1" > /etc/cron.d/pg_tasks && \
+    echo '0 0 * * * /usr/local/bin/pg_backup.sh >> /logs/pg/backup/backup_$(date +\\%Y\\%m\\%d).log 2>&1' >> /etc/cron.d/pg_tasks && \
+    echo "10 0 * * * /usr/local/bin/pg_cleanup_old.sh >> /logs/pg/cleanup/cleanup.log 2>&1" >> /etc/cron.d/pg_tasks && \
+    echo '10 0 * * * /usr/local/bin/pg_cleanup_old.sh >> /logs/pg/cleanup/cleanup_$(date +\\%Y\\%m\\%d).log 2>&1' >> /etc/cron.d/pg_tasks && \
+    chmod 0644 /etc/cron.d/pg_tasks
+
+CMD ["cron", "-f"]

--- a/app/services/user_event_service.py
+++ b/app/services/user_event_service.py
@@ -7,7 +7,7 @@ from datetime import datetime, timezone
 es = Elasticsearch(settings.ELASTICSEARCH_HOSTS)
 
 class UserEventService:
-    INDEX = "user-logs"
+    INDEX = "user-events"
 
     @classmethod
     def log_event(

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -3,8 +3,6 @@ services:
   db:
     image: postgres:14
     container_name: tripmateai-postgres
-    env_file:
-      - .env.db
     environment:
       POSTGRES_USER: ${POSTGRES_USER}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
@@ -13,13 +11,12 @@ services:
       - "5432:5432"
     volumes:
       - tripmateai-data:/var/lib/postgresql/data
+      - ./db/backup:/backup
 
 
   elasticsearch:
     image: elastic/elasticsearch:8.15.2
     container_name: tripmateai-elasticsearch
-    env_file:
-      - .env.docker
     environment:
       - discovery.type=single-node
       - xpack.security.enabled=false
@@ -32,14 +29,32 @@ services:
   kibana:
     image: docker.elastic.co/kibana/kibana:8.15.2
     container_name: kibana
-    env_file:
-      - .env.docker
     environment:
       - ELASTICSEARCH_HOSTS=${ELASTICSEARCH_HOSTS}
     ports:
       - "5601:5601"
     depends_on:
       - elasticsearch
+
+  redis:
+    image: redis:7
+    container_name: tripmateai-redis
+    ports:
+      - "16379:6379"
+    restart: unless-stopped
+    
+  pg_backup:
+    build:
+      context: .
+      dockerfile: Dockerfile.pgbackup
+    container_name: tripmateai-pgbackup
+    depends_on:
+      - db
+    volumes:
+      - ./scripts:/scripts
+      - ./db/backup:/backup
+      - ./logs:/logs
+    restart: unless-stopped
 
 volumes:
   tripmateai-data:

--- a/scripts/pg_backup.sh
+++ b/scripts/pg_backup.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+DB_NAME="${POSTGRES_DB}"
+DB_USER="${POSTGRES_USER}"
+DB_HOST="db"
+BACKUP_DIR="/backup"
+DATE=$(date +%Y%m%d_%H%M)
+FILENAME="${DB_NAME}_${DATE}.sql.gz"
+
+export PGPASSWORD="${POSTGRES_PASSWORD}"
+
+echo "[+] 백업 시작: ${FILENAME}"
+pg_dump -h "$DB_HOST" -U "$DB_USER" "$DB_NAME" | gzip > "${BACKUP_DIR}/${FILENAME}"
+echo "[+] 백업 완료: ${FILENAME}"

--- a/scripts/pg_cleanup_old.sh
+++ b/scripts/pg_cleanup_old.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+BACKUP_DIR="/backup"
+LOG_DIR="/logs/pg"
+DAYS=30
+
+echo "[*] ${DAYS}일 지난 백업 및 로그 삭제 시작"
+
+# 백업 파일 삭제
+find "$BACKUP_DIR" -type f -name "*.sql.gz" -mtime +$DAYS -exec rm -f {} \;
+
+# 일별 로그 삭제
+find "$LOG_DIR/backup" -type f -name "backup_*.log" -mtime +$DAYS -exec rm -f {} \;
+find "$LOG_DIR/cleanup" -type f -name "cleanup_*.log" -mtime +$DAYS -exec rm -f {} \;
+
+echo "[*] 삭제 완료"

--- a/scripts/seed_db.py
+++ b/scripts/seed_db.py
@@ -1,1 +1,0 @@
-# placeholder

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,6 +14,7 @@ from app.db.session import get_db
 from app.services import user_event_service
 from app.core.config import settings
 
+assert settings.ENV != "local", "local 환경에서 테스트를 실행하면 안 됩니다."
 
 # ─── in-memory SQLite 설정 ────────────────────────────────────────────────────
 SQLALCHEMY_DATABASE_URL = "sqlite:///:memory:"
@@ -120,16 +121,15 @@ def es_test_client(es_container, client) -> TestClient:
     else:
         raise RuntimeError("Elasticsearch did not start in time.")
 
-    if not new_es.indices.exists(index="user-logs"):
+    if not new_es.indices.exists(index="user-events"):
         new_es.indices.create(
-            index="user-logs",
+            index="user-events",
             body={
                 "mappings": {
                     "properties": {
                         "user_id":     {"type": "keyword"},
                         "location_id": {"type": "keyword"},
                         "action":      {"type": "keyword"},
-                        "value":       {"type": "float"},
                         "timestamp":   {"type": "date"},
                     }
                 }


### PR DESCRIPTION
## 개요
- ElasticSearch 인덱스 구조 개선 및 PostgreSQL 자동 백업 인프라 구축을 포함한 기능 개선 PR입니다.
- 기존 인덱스명을 `user-logs` → `user-events`로 통일하고, 매핑 스키마를 명시적으로 선언하여 데이터 구조의 안정성과 유지보수성을 확보했습니다.
- PostgreSQL 백업/정리 자동화를 위한 `pg_backup` 전용 컨테이너 도입 및 crontab 기반 스케줄링 구성

## 주요 변경 사항

### ElasticSearch 관련 개선
- scripts/populate_dummy_data.py
  - `_index: "user-logs"` → `"user-events"`로 변경
  - 인덱스 매핑 스키마 명시 (`user_id`, `location_id`, `action`, `timestamp`)
  - Bulk 삽입 성공/실패 건수 출력 추가
- app/services/user_event_service.py
  - UserEventService.INDEX를 `"user-events"`로 통일
- tests/conftest.py
  - 테스트 인덱스를 `user-events`로 변경
  - 사용되지 않는 value 필드 제거
  - `ENV=local` 환경에서 테스트 실행 방지 코드 추가

### PostgreSQL 백업 자동화 인프라 도입
- docker-compose.yaml
  - `.env.db`, `.env.docker` 제거
  - `redis`, `pg_backup` 서비스 추가
- Dockerfile.pgbackup (신규)
  - `cron` 설치 및 스크립트 등록
  - 매일 00시 백업, 10시 정리 작업 등록
- scripts/pg_backup.sh (신규)
  - `pg_dump`로 gzip 압축 백업 수행
  - 로그 출력 포함
- scripts/pg_cleanup_old.sh (신규)
  - 30일 이상 지난 `.sql.gz` 및 `.log` 파일 삭제
  - 백업 로그와 정리 로그를 별도로 관리

## 변경 사유
- 서비스 전반과 테스트 간 인덱스 일관성 확보
- 스키마 명시로 인한 데이터 구조 안정성 향상
- 실수로 로컬 환경에서 테스트 실행되는 것을 방지

