### PR TITLE
feat: 추천 API에 model/mvp 방식 통합 및 캐시 저장 로직 구현

### DIFF
--- a/app/api/v1/schemas/recommendation.py
+++ b/app/api/v1/schemas/recommendation.py
@@ -1,0 +1,14 @@
+from typing import List, Optional
+from pydantic import BaseModel
+from uuid import UUID
+from app.api.v1.schemas.location import LocationResponse  # 기존 Location 스키마 재사용
+
+class RecommendationRequest(BaseModel):
+    user_id: str
+    tags: List[str]
+    days: int
+    per_day_count: int
+    method: Optional[str] = "auto"  # "auto" | "model" | "mvp"
+
+class RecommendationResponse(BaseModel):
+    schedule: List[List[LocationResponse]]

--- a/app/batch/location/recommendation/load_model.py
+++ b/app/batch/location/recommendation/load_model.py
@@ -1,0 +1,43 @@
+import os
+import pickle
+from lightfm import LightFM
+from datetime import datetime
+from scipy.sparse import csr_matrix
+
+
+BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+MODEL_DIR = os.path.join(BASE_DIR, "models")
+
+def load_trained_model(date_str: str = None) -> tuple[LightFM, dict, dict, csr_matrix]:
+    """
+    LightFM 모델과 인덱스 정보 로드
+    date_str: '20250524' 같은 날짜 문자열 (기본은 오늘 날짜)
+    """
+    if date_str is None:
+        date_str = datetime.now().strftime("%Y%m%d")
+
+    path = os.path.join(MODEL_DIR, f"lightfm_model_{date_str}.pkl")
+    # path = os.path.join(MODEL_DIR, f"lightfm_model.pkl")
+    if not os.path.exists(path):
+        raise FileNotFoundError(f"모델 파일이 존재하지 않습니다: {path}")
+
+    with open(path, "rb") as f:
+        data = pickle.load(f)
+        return data["model"], data["user_idx"], data["item_idx"], data["item_features"]
+
+
+def load_user_interactions(date_str: str = None) -> tuple[dict, dict, dict]:
+    """
+    모델 학습 당시 저장된 유저-아이템 인덱스 정보만 불러옴
+    """
+    if date_str is None:
+        date_str = datetime.now().strftime("%Y%m%d")
+
+    path = os.path.join(MODEL_DIR, f"lightfm_model_{date_str}.pkl")
+    # path = os.path.join(MODEL_DIR, f"lightfm_model.pkl")
+    if not os.path.exists(path):
+        raise FileNotFoundError(f"모델 파일이 존재하지 않습니다: {path}")
+
+    with open(path, "rb") as f:
+        data = pickle.load(f)
+        return data["user_idx"], data["item_idx"], {v: k for k, v in data["item_idx"].items()}

--- a/app/services/recommendation_service.py
+++ b/app/services/recommendation_service.py
@@ -1,12 +1,29 @@
 import math
+import json
+import redis
+from datetime import datetime, timedelta
 from sqlalchemy.orm import Session
+from lightfm import LightFM
+from uuid import UUID 
+
 from app.db.models.location import Location
+from app.batch.location.recommendation.load_model import load_trained_model, load_user_interactions
+from app.core.config import settings
+
+
+
+# Redis 클라이언트
+redis_client = redis.Redis(
+    host=settings.REDIS_HOST,
+    port=settings.REDIS_PORT,
+    decode_responses=True
+)
 
 def haversine(lon1, lat1, lon2, lat2):
-    R = 6371  # 지구 반경 (km)
+    R = 6371
     dlat = math.radians(lat2 - lat1)
     dlon = math.radians(lon2 - lon1)
-    a = math.sin(dlat/2)**2 + math.cos(math.radians(lat1)) * math.cos(math.radians(lat2)) * math.sin(dlon/2)**2
+    a = math.sin(dlat / 2) ** 2 + math.cos(math.radians(lat1)) * math.cos(math.radians(lat2)) * math.sin(dlon / 2) ** 2
     c = 2 * math.atan2(math.sqrt(a), math.sqrt(1 - a))
     return R * c
 
@@ -24,15 +41,13 @@ class RecommendationService:
         per_day_count: int,
         db: Session
     ) -> list[list[Location]]:
-        # 1) 후보 전부 로드 (하남시 데이터만 DB에 있으므로)
         candidates = (
             db.query(Location)
             .filter(Location.delete_yn == 'N', Location.use_yn == 'Y')
             .all()
         )
 
-        # 2) 스코어링
-        center_x, center_y = 127.192889, 37.563083  # 하남 미사역 기준 좌표
+        center_x, center_y = 127.192889, 37.563083  # 하남 미사역
         tag_set = set(tags)
         scored: list[tuple[Location, float]] = []
 
@@ -41,19 +56,125 @@ class RecommendationService:
             content_score = jaccard(tag_set, poi_tags)
             dist = haversine(center_x, center_y, float(loc.x), float(loc.y))
             dist_score = 1 / (1 + dist)
-            # 태그 70%, 거리 30% 가중합
             score = content_score * 0.7 + dist_score * 0.3
             scored.append((loc, score))
 
-        # 3) 상위 선택 및 일별 그룹화
         scored.sort(key=lambda x: x[1], reverse=True)
         total = days * per_day_count
         top_locs = [loc for loc, _ in scored[:total]]
 
-        schedule: list[list[Location]] = []
+        schedule = []
         for d in range(days):
             start = d * per_day_count
             end = start + per_day_count
             schedule.append(top_locs[start:end])
 
         return schedule
+
+    @classmethod
+    def recommend_model(
+        cls,
+        user_id: str,
+        days: int,
+        per_day_count: int,
+        db: Session,
+        fallback_tags: list[str] = None
+    ) -> list[list[Location]]:
+        model: LightFM
+        user_map: dict
+        item_map: dict
+
+        model, user_map, item_map, item_features  = load_trained_model()
+        user_idx = user_map.get(user_id)
+
+        if user_idx is None:
+            if fallback_tags:
+                print(f">>> 사용자 로그 없음 → MVP 방식으로 대체 추천")
+                return cls.recommend_mvp(fallback_tags, days, per_day_count, db)
+            else:
+                return []
+
+        scores = model.predict(
+            user_ids=user_idx,
+            item_ids=list(range(len(item_map))),
+            item_features=item_features
+        )
+        top_items = sorted(zip(range(len(scores)), scores), key=lambda x: x[1], reverse=True)
+
+        total = days * per_day_count
+        top_location_ids = [list(item_map.keys())[i] for i, _ in top_items[:total]]
+        top_location_ids = [UUID(loc_id) for loc_id in top_location_ids]
+        print(f">>> total items in model: {len(item_map)}")
+        print(f">>> top_location_ids: {top_location_ids}")
+
+        locations = db.query(Location).filter(Location.id.in_(top_location_ids)).all()
+        id_to_loc = {str(loc.id): loc for loc in locations}
+        sorted_locs = [id_to_loc[str(loc_id)] for loc_id in top_location_ids if str(loc_id) in id_to_loc]
+        print(f">>> model top ids: {top_location_ids}")
+        print(f">>> DB에 실제 존재하는 id: {id_to_loc}")
+
+        schedule = []
+        for d in range(days):
+            start = d * per_day_count
+            end = start + per_day_count
+            schedule.append(sorted_locs[start:end])
+
+        return schedule
+
+    @classmethod
+    def recommend(
+        cls,
+        method: str,
+        user_id: str,
+        tags: list[str],
+        days: int,
+        per_day_count: int,
+        db: Session
+    ) -> list[list[Location]]:
+        if method == "mvp":
+            return cls.recommend_mvp(tags, days, per_day_count, db)
+        elif method == "model":
+            return cls.recommend_model(user_id, days, per_day_count, db, fallback_tags=tags)
+        elif method == "auto":
+            user_map, _, _ = load_user_interactions()
+            if user_id in user_map:
+                print("recommend_model")
+                return cls.recommend_model(user_id, days, per_day_count, db, fallback_tags=tags)
+            else:
+                print("recommend_mvp")
+                return cls.recommend_mvp(tags, days, per_day_count, db)
+        else:
+            raise ValueError(f"Unknown recommendation method: {method}")
+
+    @classmethod
+    def recommend_with_cache(
+        cls,
+        method: str,
+        user_id: str,
+        tags: list[str],
+        days: int,
+        per_day_count: int,
+        db: Session
+    ) -> list[list[Location]]:
+        model_version = datetime.now().strftime("%Y%m%d")
+        key = f"recommend:{method}:{user_id}:{model_version}"
+
+        if redis_client.exists(key):
+            location_ids = json.loads(redis_client.get(key))
+        else:
+            results = cls.recommend(method, user_id, tags, days, per_day_count, db)
+            location_ids = [[str(loc.id) for loc in day] for day in results]
+
+            # TTL: 다음날 새벽 1시까지
+            now = datetime.now()
+            expire_at = now.replace(hour=1, minute=0, second=0, microsecond=0)
+            if now.hour >= 1:
+                expire_at += timedelta(days=1)
+            ttl = int((expire_at - now).total_seconds())
+
+            redis_client.setex(key, ttl, json.dumps(location_ids))
+
+        flat_ids = [id for day in location_ids for id in day]
+        locations = db.query(Location).filter(Location.id.in_(flat_ids)).all()
+        id_map = {str(loc.id): loc for loc in locations}
+        return [[id_map[loc_id] for loc_id in day if loc_id in id_map] for day in location_ids]


### PR DESCRIPTION
## 개요
- 기존 MVP 기반의 태그·거리 추천 알고리즘에 더해, LightFM 모델을 이용한 추천 로직을 추가하였습니다.
- 모델 기반 추천 결과에 대해 Redis 캐시를 활용하여 일정 기간 저장 및 재사용되도록 구현하였습니다.
- `/recommend` 단일 API로 model / mvp / auto 방식 선택 가능.


## 주요 변경 파일

- `app/services/recommendation_service.py`
  - `recommend_model`, `recommend_with_cache` 메서드 추가
  - UUID ↔ str 불일치로 인한 매핑 오류 해결
- `app/api/v1/routers/recommendation.py`
  - 기존 `/recommendations/mvp` → 통합형 `/recommend` API로 변경
- `app/api/v1/schemas/recommendation.py` (신규)
  - 요청 및 응답 스키마 분리
- `app/batch/location/recommendation/load_model.py` (신규)
  - 학습된 LightFM 모델 및 user/item map 불러오는 유틸 함수 작성


## 기능 요약

- 추천 방식 선택:
  - `"mvp"`: 태그 유사도 + 거리 기반 추천
  - `"model"`: LightFM 기반 개인화 추천
  - `"auto"`: 유저 로그가 존재할 경우 model 사용, 없을 경우 mvp fallback
- Redis 캐시:
  - `recommend:{method}:{user_id}:{YYYYMMDD}` 키로 캐싱
  - 매일 새벽 1시에 만료되도록 TTL 설정
- ID 매핑 문제 해결:
  - UUID ↔ 문자열 key 불일치 문제 수정 (`str(loc.id)` 기반)


## 참고

- 학습된 LightFM 모델은 `app/batch/location/recommendation/models/` 아래 `lightfm_model_YYYYMMDD.pkl` 형식으로 저장되어야 합니다.
- 모델 포맷: `{"model": ..., "user_idx": ..., "item_idx": ..., "item_features": ...}`


## 향후 과제

- 추천 결과 개선을 위한 score tuning 및 popularity fallback 방식 추가
