### PR TITLE
feat: 일정(Itinerary) 조회 및 삭제 기능 추가

### DIFF
--- a/app/api/v1/routers/itinerary.py
+++ b/app/api/v1/routers/itinerary.py
@@ -1,7 +1,77 @@
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.orm import Session
 from app.db.session import get_db
+from app.db.models.itinerary import Itinerary
+from app.db.models.itinerary_step import ItineraryStep
+from uuid import UUID
+from typing import List
+from app.api.v1.schemas.itinerary import ItineraryWithStepsResponse, ItineraryResponse
+from app.api.v1.schemas.itinerary_step import ItineraryStepResponse
 
 
 router = APIRouter(prefix="/itinerary", tags=["itinerary"])
+
+@router.get("/user/{user_id}", response_model=List[ItineraryWithStepsResponse])
+def get_user_itineraries(user_id: str, db: Session = Depends(get_db)):
+    try:
+        user_uuid = UUID(user_id)
+        itineraries = db.query(Itinerary).filter(
+            Itinerary.user_id == user_uuid,
+            Itinerary.delete_yn == 'N',
+            Itinerary.use_yn == 'Y',
+        ).order_by(Itinerary.start_date).all()
+        result = []
+        for it in itineraries:
+            steps = db.query(ItineraryStep).filter(
+                ItineraryStep.itinerary_id == it.id,
+                ItineraryStep.delete_yn == 'N',
+                ItineraryStep.use_yn == 'Y',
+            ).order_by(ItineraryStep.date, ItineraryStep.start_time).all()
+            result.append(ItineraryWithStepsResponse(
+                itinerary=ItineraryResponse(
+                    id=it.id,
+                    start_date=it.start_date,
+                    end_date=it.end_date,
+                    use_yn=it.use_yn,
+                    delete_yn=it.delete_yn,
+                    created_at=it.created_at,
+                    updated_at=it.updated_at,
+                    deleted_at=it.deleted_at,
+                ),
+                steps=[
+                    ItineraryStepResponse(
+                        itinerary_id=step.itinerary_id,
+                        step_id=step.id,
+                        step_order=step.step_order,
+                        location_id=step.location_id,
+                        date=step.date,
+                        start_time=step.start_time,
+                        end_time=step.end_time,
+                    ) for step in steps
+                ]
+            ))
+        return result
+    except Exception as e:
+        print(">>> Itinerary List API Error:", e)
+        raise HTTPException(status_code=500, detail=str(e))
+
+@router.delete("/{itinerary_id}")
+def delete_itinerary(itinerary_id: str, db: Session = Depends(get_db)):
+    try:
+        itinerary = db.query(Itinerary).filter(Itinerary.id == UUID(itinerary_id), Itinerary.delete_yn == 'N').first()
+        if not itinerary:
+            raise HTTPException(status_code=404, detail="해당 일정이 존재하지 않거나 이미 삭제됨")
+        itinerary.delete_yn = 'Y'
+        db.add(itinerary)
+        steps = db.query(ItineraryStep).filter(ItineraryStep.itinerary_id == itinerary.id, ItineraryStep.delete_yn == 'N').all()
+        for step in steps:
+            step.delete_yn = 'Y'
+            db.add(step)
+        db.commit()
+        return {"result": "success"}
+    except HTTPException as e:
+        raise e
+    except Exception as e:
+        print(">>> Itinerary Delete API Error:", e)
+        raise HTTPException(status_code=500, detail=str(e))
 

--- a/app/api/v1/routers/itinerary.py
+++ b/app/api/v1/routers/itinerary.py
@@ -1,56 +1,17 @@
 from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.orm import Session
 from app.db.session import get_db
-from app.db.models.itinerary import Itinerary
-from app.db.models.itinerary_step import ItineraryStep
 from uuid import UUID
 from typing import List
-from app.api.v1.schemas.itinerary import ItineraryWithStepsResponse, ItineraryResponse
-from app.api.v1.schemas.itinerary_step import ItineraryStepResponse
-
+from app.api.v1.schemas.itinerary import ItineraryWithStepsResponse
+from app.services.itinerary_service import get_user_itineraries, delete_itinerary_with_steps
 
 router = APIRouter(prefix="/itinerary", tags=["itinerary"])
 
 @router.get("/user/{user_id}", response_model=List[ItineraryWithStepsResponse])
-def get_user_itineraries(user_id: str, db: Session = Depends(get_db)):
+def get_user_itineraries_router(user_id: str, db: Session = Depends(get_db)):
     try:
-        user_uuid = UUID(user_id)
-        itineraries = db.query(Itinerary).filter(
-            Itinerary.user_id == user_uuid,
-            Itinerary.delete_yn == 'N',
-            Itinerary.use_yn == 'Y',
-        ).order_by(Itinerary.start_date).all()
-        result = []
-        for it in itineraries:
-            steps = db.query(ItineraryStep).filter(
-                ItineraryStep.itinerary_id == it.id,
-                ItineraryStep.delete_yn == 'N',
-                ItineraryStep.use_yn == 'Y',
-            ).order_by(ItineraryStep.date, ItineraryStep.start_time).all()
-            result.append(ItineraryWithStepsResponse(
-                itinerary=ItineraryResponse(
-                    id=it.id,
-                    start_date=it.start_date,
-                    end_date=it.end_date,
-                    use_yn=it.use_yn,
-                    delete_yn=it.delete_yn,
-                    created_at=it.created_at,
-                    updated_at=it.updated_at,
-                    deleted_at=it.deleted_at,
-                ),
-                steps=[
-                    ItineraryStepResponse(
-                        itinerary_id=step.itinerary_id,
-                        step_id=step.id,
-                        step_order=step.step_order,
-                        location_id=step.location_id,
-                        date=step.date,
-                        start_time=step.start_time,
-                        end_time=step.end_time,
-                    ) for step in steps
-                ]
-            ))
-        return result
+        return get_user_itineraries(user_id, db)
     except Exception as e:
         print(">>> Itinerary List API Error:", e)
         raise HTTPException(status_code=500, detail=str(e))
@@ -58,16 +19,7 @@ def get_user_itineraries(user_id: str, db: Session = Depends(get_db)):
 @router.delete("/{itinerary_id}")
 def delete_itinerary(itinerary_id: str, db: Session = Depends(get_db)):
     try:
-        itinerary = db.query(Itinerary).filter(Itinerary.id == UUID(itinerary_id), Itinerary.delete_yn == 'N').first()
-        if not itinerary:
-            raise HTTPException(status_code=404, detail="해당 일정이 존재하지 않거나 이미 삭제됨")
-        itinerary.delete_yn = 'Y'
-        db.add(itinerary)
-        steps = db.query(ItineraryStep).filter(ItineraryStep.itinerary_id == itinerary.id, ItineraryStep.delete_yn == 'N').all()
-        for step in steps:
-            step.delete_yn = 'Y'
-            db.add(step)
-        db.commit()
+        delete_itinerary_with_steps(itinerary_id, db)
         return {"result": "success"}
     except HTTPException as e:
         raise e

--- a/app/api/v1/schemas/itinerary.py
+++ b/app/api/v1/schemas/itinerary.py
@@ -1,0 +1,23 @@
+from pydantic import BaseModel
+from typing import List, Optional
+from uuid import UUID
+from datetime import date, datetime
+from app.api.v1.schemas.itinerary_step import ItineraryStepResponse
+
+class ItineraryResponse(BaseModel):
+    id: UUID
+    start_date: date
+    end_date: date
+    use_yn: str
+    delete_yn: str
+    created_at: datetime
+    updated_at: datetime
+    deleted_at: Optional[datetime]
+
+    model_config = {"from_attributes": True}
+
+class ItineraryWithStepsResponse(BaseModel):
+    itinerary: ItineraryResponse
+    steps: List[ItineraryStepResponse]
+
+    model_config = {"from_attributes": True}

--- a/app/services/itinerary_service.py
+++ b/app/services/itinerary_service.py
@@ -1,0 +1,59 @@
+from sqlalchemy.orm import Session
+from uuid import UUID
+from typing import List
+from app.db.models.itinerary import Itinerary
+from app.db.models.itinerary_step import ItineraryStep
+from app.api.v1.schemas.itinerary import ItineraryWithStepsResponse, ItineraryResponse
+from app.api.v1.schemas.itinerary_step import ItineraryStepResponse
+from fastapi import HTTPException
+
+def get_user_itineraries(user_id: str, db: Session) -> List[ItineraryWithStepsResponse]:
+    user_uuid = UUID(user_id)
+    itineraries = db.query(Itinerary).filter(
+        Itinerary.user_id == user_uuid,
+        Itinerary.delete_yn == 'N',
+        Itinerary.use_yn == 'Y',
+    ).order_by(Itinerary.start_date).all()
+    result = []
+    for it in itineraries:
+        steps = db.query(ItineraryStep).filter(
+            ItineraryStep.itinerary_id == it.id,
+            ItineraryStep.delete_yn == 'N',
+            ItineraryStep.use_yn == 'Y',
+        ).order_by(ItineraryStep.date, ItineraryStep.start_time).all()
+        result.append(ItineraryWithStepsResponse(
+            itinerary=ItineraryResponse(
+                id=it.id,
+                start_date=it.start_date,
+                end_date=it.end_date,
+                use_yn=it.use_yn,
+                delete_yn=it.delete_yn,
+                created_at=it.created_at,
+                updated_at=it.updated_at,
+                deleted_at=it.deleted_at,
+            ),
+            steps=[
+                ItineraryStepResponse(
+                    itinerary_id=step.itinerary_id,
+                    step_id=step.id,
+                    step_order=step.step_order,
+                    location_id=step.location_id,
+                    date=step.date,
+                    start_time=step.start_time,
+                    end_time=step.end_time,
+                ) for step in steps
+            ]
+        ))
+    return result
+
+def delete_itinerary_with_steps(itinerary_id: str, db: Session) -> None:
+    itinerary = db.query(Itinerary).filter(Itinerary.id == UUID(itinerary_id), Itinerary.delete_yn == 'N').first()
+    if not itinerary:
+        raise HTTPException(status_code=404, detail="해당 일정이 존재하지 않거나 이미 삭제됨")
+    itinerary.delete_yn = 'Y'
+    db.add(itinerary)
+    steps = db.query(ItineraryStep).filter(ItineraryStep.itinerary_id == itinerary.id, ItineraryStep.delete_yn == 'N').all()
+    for step in steps:
+        step.delete_yn = 'Y'
+        db.add(step)
+    db.commit() 

--- a/tests/integration/test_itinerary_router.py
+++ b/tests/integration/test_itinerary_router.py
@@ -1,0 +1,96 @@
+import pytest
+from fastapi.testclient import TestClient
+from app.main import app
+from uuid import uuid4, UUID
+from datetime import datetime, date, timedelta
+from app.db.models.itinerary import Itinerary
+from app.db.models.itinerary_step import ItineraryStep
+import os
+from tests.utils.load_locations_csv import load_locations_from_csv
+
+client = TestClient(app)
+
+CSV_PATH = "/tmp/locations_for_test.csv"
+
+@pytest.fixture(autouse=True)
+def load_test_locations(db_session):
+    if os.path.exists(CSV_PATH):
+        print(f">>> 테스트용 location CSV 로딩: {CSV_PATH}")
+        load_locations_from_csv(CSV_PATH, db_session)
+    else:
+        print(f"⚠️ 테스트용 location CSV 파일이 존재하지 않음: {CSV_PATH}")
+
+@pytest.fixture
+def user_id():
+    return str(uuid4())
+
+@pytest.fixture
+def location_id(db_session):
+    from app.db.models.location import Location
+    loc = db_session.query(Location).first()
+    return str(loc.id) if loc else str(uuid4())
+
+@pytest.fixture
+def today():
+    return date.today()
+
+def make_payload(user_id, location_id, date_, start, end, itinerary_id=None):
+    payload = {
+        "user_id": user_id,
+        "location_id": location_id,
+        "date": str(date_),
+        "start_time": start.isoformat(),
+        "end_time": end.isoformat(),
+    }
+    if itinerary_id:
+        payload["itinerary_id"] = itinerary_id
+    return payload
+
+def test_itinerary_list_and_delete(client, user_id, location_id, today, db_session):
+    # 1. 일정 2개 생성 (각각 step 2개)
+    t0 = datetime.combine(today, datetime.min.time())
+    t1 = t0 + timedelta(hours=1)
+    t2 = t0 + timedelta(days=1)
+    t3 = t2 + timedelta(hours=1)
+    # 첫 번째 일정
+    res1 = client.post("/itinerary-step", json=make_payload(user_id, location_id, today, t0, t1))
+    it1_id = res1.json()["itinerary_id"]
+    client.post("/itinerary-step", json=make_payload(user_id, location_id, today, t1, t1+timedelta(hours=1), it1_id))
+    # 두 번째 일정
+    res2 = client.post("/itinerary-step", json=make_payload(user_id, location_id, today+timedelta(days=1), t2, t3))
+    it2_id = res2.json()["itinerary_id"]
+    client.post("/itinerary-step", json=make_payload(user_id, location_id, today+timedelta(days=1), t3, t3+timedelta(hours=1), it2_id))
+
+    # 2. 전체 일정 조회
+    list_res = client.get(f"/itinerary/user/{user_id}")
+    assert list_res.status_code == 200
+    data = list_res.json()
+    assert len(data) == 2
+    for it in data:
+        assert "itinerary" in it and "steps" in it
+        assert isinstance(it["steps"], list)
+        assert isinstance(it["itinerary"], dict)
+        assert len(it["steps"]) == 2
+        for step in it["steps"]:
+            assert "step_id" in step
+            assert "location_id" in step
+            assert "step_order" in step
+            assert "date" in step
+            assert "start_time" in step
+            assert "end_time" in step
+
+    # 3. 첫 번째 일정 삭제
+    del_res = client.delete(f"/itinerary/{it1_id}")
+    assert del_res.status_code == 200
+    # 4. 다시 전체 일정 조회 (1개만 남아야 함)
+    list_res2 = client.get(f"/itinerary/user/{user_id}")
+    assert list_res2.status_code == 200
+    data2 = list_res2.json()
+    assert len(data2) == 1
+    assert data2[0]["itinerary"]["id"] == it2_id
+    # 5. DB에서 step도 모두 soft delete 되었는지 확인
+    steps = db_session.query(ItineraryStep).filter(ItineraryStep.itinerary_id == UUID(it1_id)).all()
+    assert all(step.delete_yn == 'Y' for step in steps)
+    # 6. 없는 일정 삭제 시 404
+    del_res2 = client.delete(f"/itinerary/{it1_id}")
+    assert del_res2.status_code == 404 


### PR DESCRIPTION
## 개요
- 일정(여행) 전체 조회 및 삭제 API의 비즈니스 로직을 서비스 계층(`app/services/itinerary_service.py`)으로 분리하여 유지보수성과 테스트 용이성을 향상
- API 응답 구조를 Pydantic 스키마(`app/api/v1/schemas/itinerary.py`) 기반으로 일원화 -> 문서화 및 타입 검증 강화
- 통합 테스트(`tests/integration/test_itinerary_router.py`)도 스키마 구조에 맞게 리팩토링하여 신뢰성을 확보


## 주요 변경사항

#### 1. **스키마 정의 및 구조화**
- **`app/api/v1/schemas/itinerary.py`**
  - `ItineraryResponse`, `ItineraryWithStepsResponse` 등 일정 전용 Pydantic 스키마 신규 정의
  - 기존 `ItineraryStepResponse`(step 스키마)와 연동하여, 일정+세부일정(steps) 구조를 명확히 표현

#### 2. **비즈니스 로직 서비스 계층 분리**
- **`app/services/itinerary_service.py`**
  - 일정 전체 조회(`get_user_itineraries`), 일정+step soft delete(`delete_itinerary_with_steps`) 등 비즈니스 로직을 서비스 계층으로 이동
  - DB 접근, 데이터 가공, 예외처리 등 핵심 로직을 서비스에서 담당

#### 3. **라우터(컨트롤러) 역할 단순화**
- **`app/api/v1/routers/itinerary.py`**
  - 라우터에서는 서비스 함수만 호출하도록 구조 개선
  - API 응답 타입을 `response_model=List[ItineraryWithStepsResponse]`로 명확히 지정
  - 예외처리(404, 500 등) 일관성 있게 처리

#### 4. **통합 테스트 코드 리팩토링**
- **`tests/integration/test_itinerary_router.py`**
  - 스키마 구조에 맞게 응답 데이터 검증 로직 수정 (`itinerary`, `steps`, `step_id` 등 필드 체크)
  - 일정/step 생성, 조회, 삭제, soft delete, 예외(404) 등 실제 운영 시나리오를 모두 반영

## 기타
- 비즈니스 로직 분리로 코드 가독성 및 재사용성, 테스트 용이성이 크게 향상됨
- 스키마 기반 응답 구조로 API 문서화 및 프론트엔드 연동 신뢰성 강화
- 추후 일정 단건 조회/생성, step 관리 등도 동일한 구조로 확장 가능
